### PR TITLE
feat!: drop async_trait usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2021"
 
 [dependencies]
 async-channel = "2.2"
-async-trait = "0.1"
 futures-channel = "0.3"
 serde = "1.0"
+trait-variant = "0.1.2"
 zbus = "4.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -38,14 +38,12 @@ If you want to have more control, it is recommended to manually create your own 
 use std::future;
 
 use mpris_server::{
-    async_trait,
     zbus::{fdo, Result},
     Metadata, PlayerInterface, Property, RootInterface, Server, Signal, Time, Volume,
 };
 
 pub struct MyPlayer;
 
-#[async_trait]
 impl RootInterface for MyPlayer {
     async fn identity(&self) -> fdo::Result<String> {
         Ok("MyPlayer".into())
@@ -54,7 +52,6 @@ impl RootInterface for MyPlayer {
     // Other methods...
 }
 
-#[async_trait]
 impl PlayerInterface for MyPlayer {
     async fn set_volume(&self, volume: Volume) -> Result<()> {
         self.volume.set(volume);

--- a/examples/local_server.rs
+++ b/examples/local_server.rs
@@ -1,7 +1,6 @@
 use std::future;
 
 use mpris_server::{
-    async_trait,
     zbus::{fdo, Result},
     LocalPlayerInterface, LocalPlaylistsInterface, LocalRootInterface, LocalServer,
     LocalTrackListInterface, LoopStatus, Metadata, PlaybackRate, PlaybackStatus, Playlist,
@@ -10,7 +9,6 @@ use mpris_server::{
 
 pub struct Player;
 
-#[async_trait(?Send)]
 impl LocalRootInterface for Player {
     async fn raise(&self) -> fdo::Result<()> {
         println!("Raise");
@@ -73,7 +71,6 @@ impl LocalRootInterface for Player {
     }
 }
 
-#[async_trait(?Send)]
 impl LocalPlayerInterface for Player {
     async fn next(&self) -> fdo::Result<()> {
         println!("Next");
@@ -216,7 +213,6 @@ impl LocalPlayerInterface for Player {
     }
 }
 
-#[async_trait(?Send)]
 impl LocalTrackListInterface for Player {
     async fn get_tracks_metadata(&self, track_ids: Vec<TrackId>) -> fdo::Result<Vec<Metadata>> {
         println!("GetTracksMetadata({:?})", track_ids);
@@ -254,7 +250,6 @@ impl LocalTrackListInterface for Player {
     }
 }
 
-#[async_trait(?Send)]
 impl LocalPlaylistsInterface for Player {
     async fn activate_playlist(&self, playlist_id: PlaylistId) -> fdo::Result<()> {
         println!("ActivatePlaylist({})", playlist_id);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,7 +1,6 @@
 use std::future;
 
 use mpris_server::{
-    async_trait,
     zbus::{fdo, Result},
     LoopStatus, Metadata, PlaybackRate, PlaybackStatus, PlayerInterface, Playlist, PlaylistId,
     PlaylistOrdering, PlaylistsInterface, Property, RootInterface, Server, Signal, Time, TrackId,
@@ -10,7 +9,6 @@ use mpris_server::{
 
 pub struct Player;
 
-#[async_trait]
 impl RootInterface for Player {
     async fn raise(&self) -> fdo::Result<()> {
         println!("Raise");
@@ -73,7 +71,6 @@ impl RootInterface for Player {
     }
 }
 
-#[async_trait]
 impl PlayerInterface for Player {
     async fn next(&self) -> fdo::Result<()> {
         println!("Next");
@@ -216,7 +213,6 @@ impl PlayerInterface for Player {
     }
 }
 
-#[async_trait]
 impl TrackListInterface for Player {
     async fn get_tracks_metadata(&self, track_ids: Vec<TrackId>) -> fdo::Result<Vec<Metadata>> {
         println!("GetTracksMetadata({:?})", track_ids);
@@ -254,7 +250,6 @@ impl TrackListInterface for Player {
     }
 }
 
-#[async_trait]
 impl PlaylistsInterface for Player {
     async fn activate_playlist(&self, playlist_id: PlaylistId) -> fdo::Result<()> {
         println!("ActivatePlaylist({})", playlist_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,40 +33,6 @@ pub mod builder {
     pub use crate::{metadata::MetadataBuilder, player::PlayerBuilder};
 }
 
-/// Retrofits support for `async fn` in trait impls and declarations.
-///
-/// Any trait declaration or trait `impl` decorated with `#[async_trait]` or
-/// `#[async_trait(?Send)]` is retrofitted with support for `async fn`s:
-///
-/// # Examples
-///
-/// ```ignore
-/// use mpris_server::{async_trait, LocalRootInterface, RootInterface};
-/// use zbus::fdo;
-///
-/// struct MyPlayer;
-///
-/// #[async_trait]
-/// impl RootInterface for MyPlayer {
-///     async fn identity(&self) -> fdo::Result<String> {
-///         Ok("MyPlayer".into())
-///     }
-///
-///     // Other methods...
-/// }
-///
-/// struct MyLocalPlayer;
-///
-/// #[async_trait(?Send)]
-/// impl LocalRootInterface for MyLocalPlayer {
-///     async fn identity(&self) -> fdo::Result<String> {
-///         Ok("MyLocalPlayer".into())
-///     }
-///
-///     // Other methods...
-/// }
-/// ```
-pub use async_trait::async_trait;
 pub use zbus;
 use zbus::{fdo, zvariant::OwnedObjectPath, Result};
 
@@ -1167,7 +1133,7 @@ macro_rules! define_iface {
 }
 
 define_iface!(
-    #[async_trait],
+    #[trait_variant::make(Send + Sync)],
     RootInterface: Send + Sync extra_docs "",
     PlayerInterface extra_docs "",
     TrackListInterface extra_docs "",
@@ -1175,7 +1141,7 @@ define_iface!(
 );
 
 define_iface!(
-    #[async_trait(?Send)],
+    #[trait_variant::make],
     LocalRootInterface extra_docs "Local version of [`RootInterface`] to be used with [`LocalServer`].",
     LocalPlayerInterface extra_docs "Local version of [`PlayerInterface`] to be used with [`LocalServer`].",
     LocalTrackListInterface extra_docs "Local version of [`TrackListInterface`] to be used with [`LocalServer`].",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub use crate::{
 
 macro_rules! define_iface {
     (#[$attr:meta],
-        $root_iface_ident:ident$(: $bound:tt $(+ $other_bounds:tt)* )? extra_docs $extra_root_docs:literal,
+        $root_iface_ident:ident extra_docs $extra_root_docs:literal,
         $player_iface_ident:ident extra_docs $extra_player_docs:literal,
         $track_list_iface_ident:ident extra_docs $extra_track_list_docs:literal,
         $playlists_iface_ident:ident extra_docs $extra_playlists_docs:literal) => {
@@ -63,7 +63,7 @@ macro_rules! define_iface {
         ///
         /// [org.mpris.MediaPlayer2]: https://specifications.freedesktop.org/mpris-spec/2.2/Media_Player.html
         #[$attr]
-        pub trait $root_iface_ident$(: $bound $(+ $other_bounds)* )?  {
+        pub trait $root_iface_ident {
             /// Brings the media player's user interface to the front using any
             /// appropriate mechanism available.
             ///
@@ -1134,7 +1134,7 @@ macro_rules! define_iface {
 
 define_iface!(
     #[trait_variant::make(Send + Sync)],
-    RootInterface: Send + Sync extra_docs "",
+    RootInterface extra_docs "",
     PlayerInterface extra_docs "",
     TrackListInterface extra_docs "",
     PlaylistsInterface extra_docs ""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1192,6 +1192,11 @@ mod tests {
 
     use super::*;
 
+    assert_trait_sub_all!(RootInterface: Send, Sync);
+    assert_trait_sub_all!(PlayerInterface: Send, Sync);
+    assert_trait_sub_all!(TrackListInterface: Send, Sync);
+    assert_trait_sub_all!(PlaylistsInterface: Send, Sync);
+
     assert_trait_sub_all!(PlayerInterface: RootInterface);
     assert_trait_sub_all!(TrackListInterface: PlayerInterface, RootInterface);
     assert_trait_sub_all!(PlaylistsInterface: PlayerInterface, RootInterface);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1141,7 +1141,7 @@ define_iface!(
 );
 
 define_iface!(
-    #[trait_variant::make],
+    #[allow(async_fn_in_trait)],
     LocalRootInterface extra_docs "Local version of [`RootInterface`] to be used with [`LocalServer`].",
     LocalPlayerInterface extra_docs "Local version of [`PlayerInterface`] to be used with [`LocalServer`].",
     LocalTrackListInterface extra_docs "Local version of [`TrackListInterface`] to be used with [`LocalServer`].",

--- a/src/local_server.rs
+++ b/src/local_server.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use async_channel::{Receiver, Sender};
-use async_trait::async_trait;
 use futures_channel::oneshot;
 use zbus::{fdo, Connection, Result};
 
@@ -137,7 +136,6 @@ impl<T> InnerImp<T> {
     }
 }
 
-#[async_trait]
 impl<T> RootInterface for InnerImp<T> {
     async fn raise(&self) -> fdo::Result<()> {
         let (tx, rx) = oneshot::channel();
@@ -213,7 +211,6 @@ impl<T> RootInterface for InnerImp<T> {
     }
 }
 
-#[async_trait]
 impl<T> PlayerInterface for InnerImp<T> {
     async fn next(&self) -> fdo::Result<()> {
         let (tx, rx) = oneshot::channel();
@@ -387,7 +384,6 @@ impl<T> PlayerInterface for InnerImp<T> {
     }
 }
 
-#[async_trait]
 impl<T> TrackListInterface for InnerImp<T>
 where
     T: LocalTrackListInterface,
@@ -444,7 +440,6 @@ where
     }
 }
 
-#[async_trait]
 impl<T> PlaylistsInterface for InnerImp<T>
 where
     T: LocalPlaylistsInterface,

--- a/src/player.rs
+++ b/src/player.rs
@@ -3,7 +3,6 @@ use std::{
     rc::{Rc, Weak},
 };
 
-use async_trait::async_trait;
 use zbus::{fdo, Result};
 
 use crate::{
@@ -87,7 +86,6 @@ impl State {
     }
 }
 
-#[async_trait(?Send)]
 impl LocalRootInterface for State {
     async fn raise(&self) -> fdo::Result<()> {
         let player = self.player();
@@ -150,7 +148,6 @@ impl LocalRootInterface for State {
     }
 }
 
-#[async_trait(?Send)]
 impl LocalPlayerInterface for State {
     async fn next(&self) -> fdo::Result<()> {
         let player = self.player();


### PR DESCRIPTION
Regressions:
- [x] Lost specialized documentation on local variants
- [x] Lost subtraits on Send versions